### PR TITLE
Disable validation on unknown field also via cli

### DIFF
--- a/avro_validator/avro_types.py
+++ b/avro_validator/avro_types.py
@@ -65,7 +65,8 @@ class ComplexType(Type):
 
         if not cls.optional_attributes.union(cls.required_attributes).issuperset(json_repr.keys()):
             raise ValueError(f'The {cls.__name__} can only contains '
-                             f'{cls.required_attributes.union(cls.optional_attributes)} keys')
+                             f'{cls.required_attributes.union(cls.optional_attributes)} keys, '
+                             f'but does contain also {set(json_repr.keys()).difference(cls.optional_attributes, cls.required_attributes)}')
 
         return True
 

--- a/avro_validator/cli.py
+++ b/avro_validator/cli.py
@@ -12,6 +12,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description='Validate json against avro schema.')
     parser.add_argument(
+        '-s', '--skip-extra-keys',
+        default=False,
+        action="store_true",
+        help='Skip the avro validation for all unknown fields.',
+    )
+    parser.add_argument(
         'schema_file',
         help='The path to the file containing the avro schema.',
     )
@@ -32,7 +38,7 @@ def main() -> None:
     schema = Schema(args.schema_file)
 
     try:
-        parsed_schema = schema.parse()
+        parsed_schema = schema.parse(args.skip_extra_keys)
     except ValueError as error:
         print('Error parsing the schema. Problem found:\n', error)
         sys.exit(1)

--- a/avro_validator/cli.py
+++ b/avro_validator/cli.py
@@ -9,9 +9,16 @@ from avro_validator.schema import Schema
 def main() -> None:
     """Main entrypoint for the command line"""
 
-    parser = argparse.ArgumentParser(description='Validate json against avro schema.')
-    parser.add_argument('schema_file', help='The path to the file containing the avro schema.')
-    parser.add_argument('data_file', help='The path to a file containing the data to validate.')
+    parser = argparse.ArgumentParser(
+        description='Validate json against avro schema.')
+    parser.add_argument(
+        'schema_file',
+        help='The path to the file containing the avro schema.',
+    )
+    parser.add_argument(
+        'data_file',
+        help='The path to a file containing the data to validate.',
+    )
     args = parser.parse_args()
 
     if not os.path.exists(args.schema_file):

--- a/avro_validator/schema.py
+++ b/avro_validator/schema.py
@@ -18,11 +18,11 @@ class Schema:
         except Exception:
             self._schema = schema
 
-    def parse(self) -> RecordType:
+    def parse(self, skip_extra_keys=False) -> RecordType:
         """Parses the schema and returns a RecordType containing the schema.
 
         Returns:
             The RecordType representing the parsed schema.
         """
         schema = json.loads(self._schema)
-        return RecordType.build(schema)
+        return RecordType.build(schema, skip_extra_keys=skip_extra_keys)


### PR DESCRIPTION
This branch is based on [pawndev:disable-validation-on-unknown-field ](https://github.com/pawndev/avro_validator/tree/disable-validation-on-unknown-field), but makes the skipping of unknown fields available via the command line interface. Hence this includes the PR #11.